### PR TITLE
Login form and view permissions

### DIFF
--- a/demodj/settings.py
+++ b/demodj/settings.py
@@ -24,7 +24,7 @@ SECRET_KEY = getenv(
     'DEMODJ_SECRET_KEY', 'django-insecure-+u()*ykdn+20wd88=-ou3)c7#h)-psb5w80)z=jr&&&wr)9)0z'
 )
 if ALLOWEDFLARE_PRIVATE_DOMAIN:
-    ALLOWED_HOSTS = (f'.{ALLOWEDFLARE_PRIVATE_DOMAIN}',)
+    ALLOWED_HOSTS = (f'.{ALLOWEDFLARE_PRIVATE_DOMAIN}', 'localhost')
     CSRF_TRUSTED_ORIGINS = (f'https://*.{ALLOWEDFLARE_PRIVATE_DOMAIN}',)
 
 # "When DEBUG is True and ALLOWED_HOSTS is empty, the host is validated against
@@ -61,9 +61,9 @@ AUTHENTICATION_BACKENDS = [
 ROOT_URLCONF = 'demodj.urls'
 
 TEMPLATES = [
-    {
+    {  # To avoid admin.E403, configure Django templates
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': ['django_allowedflare'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/demodj/urls.py
+++ b/demodj/urls.py
@@ -14,7 +14,13 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
+from django.contrib.admin import site
 from django.urls import path
 
-urlpatterns = [path('admin/', admin.site.urls)]
+from django_allowedflare import AllowedflareLoginView
+
+
+urlpatterns = [
+    path('admin/login/', AllowedflareLoginView.as_view(), name='admin-login'),
+    path('admin/', site.urls),
+]

--- a/django_allowedflare/login.html
+++ b/django_allowedflare/login.html
@@ -1,0 +1,6 @@
+{% extends 'admin/login.html' %}
+
+{% block content %}
+    <p>{{allowedflare_message}}</p>
+    {{ block.super }}
+{% endblock %}

--- a/django_allowedflare/test.py
+++ b/django_allowedflare/test.py
@@ -1,0 +1,41 @@
+from sys import modules
+
+from django.test import SimpleTestCase
+
+from django_allowedflare import clean_username
+
+
+class Test(SimpleTestCase):
+    def test_clean_username(self):
+        with self.settings(
+            ALLOWEDFLARE_EMAIL_DOMAIN='off', ALLOWEDFLARE_PRIVATE_DOMAIN='domain.com'
+        ):
+            self.assertEqual(clean_username('user@domain.com'), 'user@domain.com')
+        with self.settings(
+            ALLOWEDFLARE_EMAIL_DOMAIN='domain.com', ALLOWEDFLARE_PRIVATE_DOMAIN='domain.dev'
+        ):
+            self.assertEqual(clean_username('user@domain.com'), 'user')
+        with self.settings(ALLOWEDFLARE_PRIVATE_DOMAIN='domain.com'):
+            self.assertEqual(clean_username('user@domain.com'), 'user')
+
+    def test_fetch_or_reuse_keys(self):
+        # Arrange: probably not parallel safe
+        try:
+            del modules['django_allowedflare']
+        except KeyError:
+            pass
+        import django_allowedflare
+
+        # Assert: initial conditions
+        self.assertEqual(django_allowedflare.cached_keys, [])
+        self.assertEqual(django_allowedflare.cache_updated.timestamp(), 0)
+        with self.settings(ALLOWEDFLARE_ACCESS_URL='https://domain.cloudflareaccess.com'):
+            # Act: TODO mock
+            keys = django_allowedflare.fetch_or_reuse_keys()
+
+        # Assert: module level variables are updated
+        self.assertEqual(django_allowedflare.cached_keys, keys)
+        self.assertGreater(django_allowedflare.cache_updated.timestamp(), 0)
+
+        # Arrange: cleanup
+        del modules['django_allowedflare']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 ---
 version: '3.9'
 services:
+    proxy:
+        image: cloudflare/cloudflared:2024.2.1
+
     postgres:
         image: postgres:15
         command: postgres -p 5501


### PR DESCRIPTION
## Changes
- Provide a module-level `authenticate()` function which both the backend class and a new auto-filling login form can use
- Switch from a `defaults_for_user()` function to an `update_user()` function, so we can add group memberships rather than set them (which might take away manually associated groups)
- Create an `allowedflare_everyone` group with all the view permissions
- Avoid setting the key cache to an empty list
- Start writing unit tests
- Add cloudflared to docker-compose.yml to begin down a path to end-to-end testing, but this hasn't been exercised at all yet

## Open Questions
- Should we switch to the `RemoteUserBackend` convention of `clean_username()` and `configure_user()`?