### PR TITLE
Rename update_user to configure_user and log again

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,3 @@
----
 name: Check
 run-name: Checking on behalf of ${{ github.actor }}
 on: # yamllint disable-line rule:truthy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
----
 default_language_version:
     python: python3.11 # Using .python-version would be nice
 repos:
@@ -9,15 +8,11 @@ repos:
           - id: ruff
             args:
                 - --fix
+          - id: ruff-format
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.5.0
       hooks:
-          - id: double-quote-string-fixer
           - id: end-of-file-fixer
-    - repo: https://github.com/psf/black
-      rev: 23.12.1
-      hooks:
-          - id: black
     - repo: https://github.com/jazzband/pip-tools
       rev: 7.3.0
       hooks:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,9 +1,9 @@
----
 extends: default
 
 rules:
     comments:
-        min-spaces-from-content: 1 # Unfortunate difference between prettier and black
+        min-spaces-from-content: 1 # Unfortunate difference between prettier and PEP8
+    document-start: disable
     indentation:
         spaces: 4
     line-length:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Configure Cloudflare Tunnel public hostname demodj.your-domain.tld to http://loc
 
 ### TODO
 * Django REST Framework (DRF) support
-* (Re-) authenticating proxy for different-domain front-ends, like https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/cors/#send-authentication-token-with-cloudflare-worker but
+* Same-origin (re-)authenticating proxy
+    - Like https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/cors/#send-authentication-token-with-cloudflare-worker
     - Setting username so it can be logged by gunicorn
     - Rewriting origin redirects
     - Setting the XmlHttpRequest(?) header to avoid redirects to the sign-in page
@@ -24,3 +25,8 @@ Configure Cloudflare Tunnel public hostname demodj.your-domain.tld to http://loc
 * Unit tests
 * Example configuration using Helicopyter
 * End-to-end tests
+
+## Open Questions
+* Should Allowedflare provide a subclass of
+  [RemoteUserMiddleware](https://docs.djangoproject.com/en/5.0/howto/auth-remote-user/)
+  to automatically login each request?

--- a/demodj/asgi.py
+++ b/demodj/asgi.py
@@ -7,7 +7,6 @@ For more information on this file, see
 https://docs.djangoproject.com/en/4.2/howto/deployment/asgi/
 """
 
-
 from django.core.asgi import get_asgi_application
 
 import default

--- a/demodj/urls.py
+++ b/demodj/urls.py
@@ -14,6 +14,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib.admin import site
 from django.urls import path
 

--- a/demodj/wsgi.py
+++ b/demodj/wsgi.py
@@ -7,7 +7,6 @@ For more information on this file, see
 https://docs.djangoproject.com/en/4.2/howto/deployment/wsgi/
 """
 
-
 from django.core.wsgi import get_wsgi_application
 
 import default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
----
 version: '3.9'
 services:
     proxy:

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import sys
 
 import default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,6 @@ readme = 'README.md'
 [project.urls]
 Homepage = 'https://github.com/covracer/allowedflare'
 
-[tool.black]
-line-length = 100
-skip-magic-trailing-comma = true
-skip-string-normalization = true
-
 [tool.ruff.format]
 quote-style = 'single'
 skip-magic-trailing-comma = true


### PR DESCRIPTION
Breaking change: `update_user` and `ALLOWEDFLARE_UPDATE_USER` renamed to `configure_user` and `ALLOWEDFLARE_CONFIGURE_USER`. Details in the new docstring.

Repair functionality lost when abstracting the authenticate function in #6:
* Early return
* Logging (varying levels not preserved)

On the tooling front:
* Move from `black` + `double-quote-string-fixer` to `ruff-format` for autoformatting
* Remove triple dash `---` YAML document separators; I cannot recall ever writing or debugging a multi-part YAML document