### PR TITLE
Configure Gunicorn

### DIFF
--- a/demodj/urls.py
+++ b/demodj/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     path('explore/', include('explorer.urls')),
     path('health/', include('health_check.urls')),
     path('api/', include(router.urls)),
+    path('sleep/', views.sleepy_view, name='sleep'),
 ]
 
 urlpatterns += router.urls

--- a/demodj/views.py
+++ b/demodj/views.py
@@ -1,7 +1,15 @@
+from time import sleep
+
 from django.contrib.auth.models import Group, User
+from django.http import HttpResponse
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from .serializers import GroupSerializer, UserSerializer
+
+
+def sleepy_view(request):
+    sleep(3)
+    return HttpResponse('OK')
 
 
 class UserViewSet(ReadOnlyModelViewSet):

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
 
     web:
         build: .
-        command: python -m manage runserver
+        command: gunicorn
         depends_on:
             - postgres
         environment:
@@ -53,7 +53,7 @@ services:
             - ALLOWEDFLARE_EMAIL_DOMAIN
             - ALLOWEDFLARE_PRIVATE_DOMAIN
         image: allowedflare:${GIHA:-local}
-        ports: # Should match manage.py
+        ports: # Should match manage.py and gunicorn.conf.py
             - 8001:8001
         pull_policy: never
         volumes:

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,28 @@
+from ast import literal_eval
+from os import getenv
+from multiprocessing import cpu_count
+
+access_log_format = '%(r)s st=%(s)s lb=%(h)s ip=%({x-forwarded-for}i)s rt=%(L)ss us=%(u)s rf=%(f)s'
+accesslog = '-'
+bind = 'localhost:8001'  # Should match docker-compose.yaml and manage.py
+reload = bool(literal_eval(getenv('GUNICORN_RELOAD', 'False')))
+workers = cpu_count() * 2 + 1
+wsgi_app = 'demodj.wsgi'
+
+
+# Called just before a worker processes the request.
+def pre_request(worker, request):
+    message = f'{request.method} {request.uri}'
+    worker.log.debug(message)
+    worker.unfinished_request = message
+
+
+# Called after a worker processes the request.
+def post_request(worker, _request, _environment, _response):
+    worker.unfinished_response = ''
+
+
+# Called when a worker received the SIGABRT signal. This call generally happens on timeout.
+def worker_abort(worker):
+    if message := getattr(worker, 'unfinished_request'):
+        worker.log.critical(f'Interrupted: {message}')

--- a/manage.py
+++ b/manage.py
@@ -13,7 +13,7 @@ def main() -> None:
         from django.core.management.commands.runserver import Command
 
         Command.default_addr = '0.0.0.0'  # noqa: S104
-        Command.default_port = '8001'  # Should match docker-compose.yml
+        Command.default_port = '8001'  # Should match docker-compose.yaml and gunicorn.conf.py
     except ImportError as exc:
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ demo = [
     'django-health-check',
     'django-sql-explorer',
     'djangorestframework',
+    'gunicorn',
     'jupyterlab',
 ]
 build = ['build', 'twine']

--- a/requirements.txt
+++ b/requirements.txt
@@ -129,6 +129,8 @@ filelock==3.18.0
     # via virtualenv
 fqdn==1.5.1
     # via jsonschema
+gunicorn==23.0.0
+    # via allowedflare (pyproject.toml)
 h11==0.14.0
     # via httpcore
 hadolint-py @ git+https://github.com/AleksaC/hadolint-py.git@a54e4d51787678062c8e108b20782f00e707a40e
@@ -299,6 +301,7 @@ overrides==7.7.0
 packaging==24.2
     # via
     #   build
+    #   gunicorn
     #   ipykernel
     #   jupyter-events
     #   jupyter-server


### PR DESCRIPTION
### Background and Links
* Gunicorn's default configuration
    - Makes searching for specific status codes hard
    - Doesn't surface the x-forwarded-for IP address, which is more likely to be the real client when load balancing is involved
    - Hides timed-out requests

### Changes and Testing
* Log in a abbr=value format that's easy to search while somewhat concise
* Include some additional information
* Try to log details of timed out requests

### Questions and Followup
* Better documentation of the log format
    - `st` STatus
    - `lb` Load Balancer IP address
    - `ip` x-forwarded-for IP address
    - `rt` Response Time
    - `us` USer
    - `rf` ReFerrer
* Right now, `us` for USer is only populated for [Basic Auth](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Authentication#basic_authentication_scheme); putting the Cloudflare user there would be great (doing that efficiently might involve transitioning to [REMOTE_USER](https://docs.djangoproject.com/en/5.1/howto/auth-remote-user/))