### PR TITLE
Fix sequence exhaustion

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,52 @@ docker compose up
 
 Configure Cloudflare Tunnel public hostname demodj.your-domain.tld to http://localhost:8001 or equivalent.
 
+## Customizing user setup
+
+On every authenticated request, the backend calls `configure_user(user, request, created)`,
+which by default makes the user staff and grants all `view_*` permissions to an
+`allowedflare_everyone` group so everyone can browse the admin site read-only. Set
+`ALLOWEDFLARE_CONFIGURE_USER` in settings to replace it.
+
+The default re-checks group permissions on every request (a few queries). If you'd rather pay
+nothing on the request path, do per-user setup only on creation and sync group permissions at
+`post_migrate` — the only moment new permissions can come into existence:
+
+```python
+# settings.py
+def ALLOWEDFLARE_CONFIGURE_USER(user, request, created):
+    from yourapp.allowedflare_user import configure_user
+    return configure_user(user, request, created)
+
+# yourapp/allowedflare_user.py
+from django.contrib.auth.models import Group, Permission
+
+def configure_user(user, request, created):
+    if created:
+        user.is_staff = True
+        user.save()
+        everyone, _ = Group.objects.get_or_create(name='allowedflare_everyone')
+        user.groups.add(everyone)
+    return user
+
+def sync_everyone_permissions(sender, **kwargs):
+    everyone, _ = Group.objects.get_or_create(name='allowedflare_everyone')
+    missing = Permission.objects.filter(codename__startswith='view').exclude(group=everyone)
+    if missing.exists():
+        everyone.permissions.add(*missing)
+
+# yourapp/apps.py
+from django.apps import AppConfig
+from django.db.models.signals import post_migrate
+
+class YourAppConfig(AppConfig):
+    name = 'yourapp'
+
+    def ready(self):
+        from yourapp.allowedflare_user import sync_everyone_permissions
+        post_migrate.connect(sync_everyone_permissions, weak=False)
+```
+
 ### TODO
 * Iterate on the same-origin (re-)authenticating proxy
     - From-scratch reimplementation of https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/cors/#send-authentication-token-with-cloudflare-worker

--- a/allowedflare/django.py
+++ b/allowedflare/django.py
@@ -25,13 +25,22 @@ def configure_user(user: User, request: HttpRequest, created: bool) -> User:
 
     To match `RemoteUserBackend.configure_user()`, `request` and `created` arguments are accepted
     but unused. The `self` argument is omitted to make user-provided replacement easier.
+
+    Because this runs on every authenticated request, it must only insert rows that are actually
+    missing. A no-op `add()` is not harmless on PostgreSQL: it runs INSERT ... ON CONFLICT DO
+    NOTHING, which consumes a sequence value per attempted row even when nothing is inserted,
+    eventually overflowing the int4 auth_group_permissions.id on busy deployments.
     """
-    user.is_staff = True
-    user.save()
+    if not user.is_staff:
+        user.is_staff = True
+        user.save()
 
     everyone, _ = Group.objects.get_or_create(name='allowedflare_everyone')
-    everyone.permissions.add(*Permission.objects.filter(codename__startswith='view'))
-    user.groups.add(everyone)
+    missing = Permission.objects.filter(codename__startswith='view').exclude(group=everyone)
+    if missing:
+        everyone.permissions.add(*missing)
+    if not user.groups.filter(pk=everyone.pk).exists():
+        user.groups.add(everyone)
     return user
 
 

--- a/allowedflare/test_django.py
+++ b/allowedflare/test_django.py
@@ -1,6 +1,10 @@
+import pytest
+from django.contrib.auth.models import Group, Permission, User
+from django.db import connection
 from django.test import RequestFactory
+from django.test.utils import CaptureQueriesContext
 
-from allowedflare.django import LoginView
+from allowedflare.django import LoginView, configure_user
 
 
 def test_allowedflare_login_view(monkeypatch, rf: RequestFactory):
@@ -8,3 +12,32 @@ def test_allowedflare_login_view(monkeypatch, rf: RequestFactory):
     response = LoginView.as_view()(rf.get(''))
     assert response.status_code == 200
     assert 'allowedflare_message' in response.context_data  # type: ignore[attr-defined]
+
+
+@pytest.mark.django_db
+def test_configure_user_attempts_no_inserts_in_steady_state(rf: RequestFactory):
+    """Repeat calls must not attempt conflicting inserts.
+
+    On PostgreSQL, M2M add() of already-present rows runs INSERT ... ON CONFLICT DO NOTHING,
+    which consumes a sequence value per attempted row even though nothing is inserted. At one
+    call per authenticated request, this eventually overflows the int4
+    auth_group_permissions.id.
+    """
+    user = User.objects.create(username='sailor')
+    configure_user(user, rf.get(''), True)
+
+    user.refresh_from_db()
+    assert user.is_staff
+    assert user.groups.filter(name='allowedflare_everyone').exists()
+    everyone = Group.objects.get(name='allowedflare_everyone')
+    assert everyone.permissions.filter(codename__startswith='view').count() == (
+        Permission.objects.filter(codename__startswith='view').count()
+    )
+
+    with CaptureQueriesContext(connection) as context:
+        configure_user(user, rf.get(''), False)
+
+    inserts = [
+        q['sql'] for q in context.captured_queries if q['sql'].lstrip().upper().startswith('INSERT')
+    ]
+    assert inserts == []


### PR DESCRIPTION
# Title

Only insert missing permissions in configure_user

# Body

Hi biobuddies, editco barb had kind of a funny issue with allowedflare today and I thought I would share the fix. AI wrote the rest of this, so apologies for the tone, but it is accurate. ✌️ 

## What happened

Our production instance went down this morning with `DataError: integer out of range` raised from inside `authenticate()` — so every request 500'd, including the ones from people trying to log in to investigate.

The trail led to the default `configure_user`, which runs on every authenticated request and does:

```python
everyone.permissions.add(*Permission.objects.filter(codename__startswith='view'))
```

Django implements M2M `add()` as `bulk_create(ignore_conflicts=True)` → `INSERT ... ON CONFLICT DO NOTHING` on Postgres. The permissions are already in the group on every request after the first, so nothing is ever inserted — **but Postgres still consumes a sequence value for every attempted row**. With ~500 `view_*` permissions and ~15 months of normal traffic, our `auth_group_permissions_id_seq` quietly counted its way to 2,147,483,647 (int4 max) and fell off the edge.

The numbers, for entertainment value:

- Rows actually in `auth_group_permissions`: ~500
- Highest id among them: 2,113,800,942
- Sequence values consumed per real row: ~4.2 million
- Times `ON CONFLICT DO NOTHING` did nothing, at a cost: ~2.1 billion

(`user.groups.add(everyone)` has the same property at 1 id/request — that one would have gotten us around the year 2600.)

A project-level `DEFAULT_AUTO_FIELD = BigAutoField` doesn't help, since the column comes from `django.contrib.auth`'s own migrations (int4 `AutoField`).

## What this PR does

**Commit 1** keeps `configure_user`'s self-healing behavior identical — it just never attempts an insert for a row that already exists. Same end state on every code path, zero insert attempts in steady state. The new regression test asserts a repeat call performs no INSERTs (sequence burn isn't observable on SQLite, so the test pins the invariant that causes it instead). It fails against the current code and passes with the fix. Full suite passes.

**Commit 2** documents the `ALLOWEDFLARE_CONFIGURE_USER` settings hook in the README — it was a great escape hatch for hotfixing this downstream, but we only found it by reading the source. The example shows a zero-request-overhead variant (per-user setup only on creation, group permission sync at `post_migrate`) for anyone who wants nothing on the request path; happy to drop or trim that section if you'd rather keep the README lean.

## For anyone else who finds this at 2am

```sql
SELECT setval('auth_group_permissions_id_seq', (SELECT COALESCE(MAX(id), 1) FROM auth_group_permissions));
-- and if your real rows are already near the ceiling (ours were):
ALTER TABLE auth_group_permissions ALTER COLUMN id TYPE bigint;
ALTER SEQUENCE auth_group_permissions_id_seq AS bigint;
```

Lesson learned: "no rows were inserted" and "no sequence values were consumed" are very different sentences.
